### PR TITLE
refactor: remove build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ The following inputs can be used as `step.with` keys and match the inputs from [
 | `metadata`   | JSON   | Build result metadata |
 | `project-id` | String | Depot Project ID      |
 | `build-id`   | String | Depot Build ID        |
-| `targets`    | Array  | Saved Bake Targets    |
 
 ## License
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -76151,7 +76151,7 @@ async function main() {
   const metadata = getMetadata();
   if (metadata) {
     await core3.group(`Metadata`, async () => {
-      var _a, _b, _c;
+      var _a, _b;
       core3.info(metadata);
       core3.setOutput("metadata", metadata);
       try {
@@ -76161,9 +76161,6 @@ async function main() {
         }
         if ((_b = parsed == null ? void 0 : parsed["depot.build"]) == null ? void 0 : _b.projectID) {
           core3.setOutput("project-id", parsed["depot.build"].projectID);
-        }
-        if ((_c = parsed == null ? void 0 : parsed["depot.build"]) == null ? void 0 : _c.targets) {
-          core3.setOutput("targets", parsed["depot.build"].targets);
         }
       } catch {
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,6 @@ async function main() {
         if (parsed?.['depot.build']?.projectID) {
           core.setOutput('project-id', parsed['depot.build'].projectID)
         }
-        if (parsed?.['depot.build']?.targets) {
-          core.setOutput('targets', parsed['depot.build'].targets)
-        }
       } catch {}
     })
   }


### PR DESCRIPTION
The build targets output is trick to use as an input. We will simplify the pull-action.