### PR TITLE
Fix broken link and a few 301s

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,16 +98,16 @@ The following inputs can be used as `step.with` keys and match the inputs from [
 
 | Name         | Type        | Description                                                                                                                                 |
 | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `files`      | List/CSV    | List of [bake definition files](https://docs.docker.com/build/customize/bake/file-definition/)                                              |
+| `files`      | List/CSV    | List of [bake definition files](https://docs.docker.com/build/bake/reference/)                                                              |
 | `workdir`    | String      | Working directory of execution                                                                                                              |
 | `targets`    | List/CSV    | List of bake targets (`default` target used if empty)                                                                                       |
 | `no-cache`   | Bool        | Do not use cache when building the image (default `false`)                                                                                  |
 | `pull`       | Bool        | Always attempt to pull a newer version of the image (default `false`)                                                                       |
 | `load`       | Bool        | Load is a shorthand for `--set=*.output=type=docker` (default `false`)                                                                      |
-| `provenance` | Bool/String | [Provenance](https://docs.docker.com/build/attestations/provenance/) is a shorthand for `--set=*.attest=type=provenance`                    |
+| `provenance` | Bool/String | [Provenance](https://docs.docker.com/build/metadata/attestations/slsa-provenance/) is a shorthand for `--set=*.attest=type=provenance`      |
 | `push`       | Bool        | Push is a shorthand for `--set=*.output=type=registry` (default `false`)                                                                    |
-| `sbom`       | Bool/String | [SBOM](https://docs.docker.com/build/attestations/sbom/) is a shorthand for `--set=*.attest=type=sbom`                                      |
-| `sbom-dir`   | String      | Save all image [SBOM](https://docs.docker.com/build/attestations/sbom/) to this output directory                                            |
+| `sbom`       | Bool/String | [SBOM](https://docs.docker.com/build/metadata/attestations/sbom/) is a shorthand for `--set=*.attest=type=sbom`                             |
+| `sbom-dir`   | String      | Save all image [SBOM](https://docs.docker.com/build/metadata/attestations/sbom/) to this output directory                                   |
 | `set`        | List        | List of [targets values to override](https://docs.docker.com/engine/reference/commandline/buildx_bake/#set) (eg: `targetpattern.key=value`) |
 
 ## Outputs


### PR DESCRIPTION
Fix a broken link to Provenance documentation, and update other links that are 301s.