### PR TITLE
feat: add save-tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This action needs a Depot API token to communicate with your project's builders.
 | `lint`           | Bool    | Lint dockerfiles and fail build if any issues are of `error` severity. (default `false`)                                                                                       |
 | `lint-fail-on`   | String  | Severity of linter issue to cause the build to fail. (`error`, `warn`, `info`, `none`)                                                                                         |
 | `save`           | Boolean | Save the image to the Depot ephemeral registry (for use with the [depot/pull-action](https://github.com/depot/pull-action))                                                    |
+| `save-tag`       | String  | Additional custom tag for the saved image, use with --save                                                    |
 
 ### General inputs
 

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,9 @@ inputs:
     description: 'Save the image to the Depot ephemeral registry'
     required: false
     default: 'false'
+  save-tag:
+    description: 'Additional custom tag for the saved image, use with --save'
+    required: false
   sbom:
     description: 'SBOM is a shorthand for --set=*.attest=type=sbom'
     required: false

--- a/src/context.ts
+++ b/src/context.ts
@@ -18,6 +18,7 @@ export interface Inputs {
   provenance: string
   push: boolean
   save: boolean
+  saveTag?: string
   sbom: string
   sbomDir: string
   set: string[]
@@ -41,6 +42,7 @@ export function getInputs(): Inputs {
     provenance: getProvenanceInput(),
     push: core.getBooleanInput('push'),
     save: core.getBooleanInput('save'),
+    saveTag: core.getInput('save-tag'),
     sbom: core.getInput('sbom'),
     sbomDir: core.getInput('sbom-dir'),
     set: Util.getInputList('set', {ignoreComma: true, quote: false}),

--- a/src/depot.ts
+++ b/src/depot.ts
@@ -109,6 +109,7 @@ export async function bake(inputs: Inputs) {
     ...flag('--lint', inputs.lint),
     ...flag('--lint-fail-on', inputs.lintFailOn),
     ...flag('--save', inputs.save),
+    ...flag('--save-tag', inputs.saveTag)
   ]
   const args = [...bakeArgs, ...depotArgs, ...targets]
 


### PR DESCRIPTION
Hello guys! 👋  I wanted to set the new `save-tag` to the short git-sha to simplify our sandbox environments, but I noticed the flag is missing. I've tested it within our pipelines under build `bvgvgfs583` and seems to work like a charm 👍 