### PR TITLE
docs: Clarify project ID precedence in bake files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This action needs a Depot API token to communicate with your project's builders.
 
 | Name             | Type    | Description                                                                                                                                                                    |
 | ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `project`        | String  | Depot [project](https://depot.dev/docs/core-concepts#projects) ID to route the image build to your projects builders (default: the `depot.json` file at the root of your repo) |
+| `project`        | String  | Depot [project](https://depot.dev/docs/core-concepts#projects) ID to route the image build to your projects builders (default: the `depot.json` file at the root of your repo)<br><br>**Note:** If you specify `x-depot.project-id` in your Docker Compose file or `project_id` in your HCL bake file for individual services/targets, those project IDs will take precedence over this parameter. |
 | `token`          | String  | You must authenticate with the Depot API to communicate with your projects builders ([see Authentication above](#authentication))                                              |
 | `build-platform` | String  | The platform to use for the build ( `linux/amd64` or `linux/arm64`)                                                                                                            |
 | `lint`           | Bool    | Lint dockerfiles and fail build if any issues are of `error` severity. (default `false`)                                                                                       |


### PR DESCRIPTION
## Summary
Added clarification to the README explaining that project IDs specified in bake files take precedence over the action's `project` parameter.

## Changes
- Updated the `project` parameter description in the "Depot-specific inputs" table to include a note about precedence
- Explains that `x-depot.project-id` (Docker Compose) and `project_id` (HCL) in bake files override the action parameter

## Context
This clarification is part of a documentation update across multiple repositories to make the parameter precedence behavior explicit. Users need to understand that when they specify project IDs at the service/target level in their bake files, those will override the global project parameter set in the GitHub Action configuration.

Related PR in the main app repository: depot/app#1865